### PR TITLE
fix: reset option selected on price change

### DIFF
--- a/widget/src/components/MainWidget/Widget.tsx
+++ b/widget/src/components/MainWidget/Widget.tsx
@@ -1,26 +1,13 @@
-import { useContext, useState } from "react";
+import { useState } from "react";
 import InfoPopUp from "../InfoPopUp/InfoPopUp";
 import Select from "../Select/Select";
 import "./Widget.css";
-import { CreditAgreementsContext } from "../../providers/CreditAgreementsProvider";
-import { CreditAgreement } from "../../hooks/useCreditAgreements";
 
 const widgetTitle = "Pagalo en";
 const moreInfoButton = "More info";
 
-const getCreditAgreementMessage = (creditAgreement: CreditAgreement) => {
-  const value = creditAgreement.instalment_count;
-  const label = `${creditAgreement.instalment_count} cuotas de ${creditAgreement.instalment_total.string}/mes`;
-  return { value, label };
-};
-
 function Widget() {
   const [isPopUpOpen, setIsPopUpOpen] = useState(false);
-
-  const { creditAgreements } = useContext(CreditAgreementsContext);
-  const financialOptions = creditAgreements.map((creditAgreement) =>
-    getCreditAgreementMessage(creditAgreement)
-  );
 
   const togglePopUp = () => setIsPopUpOpen(!isPopUpOpen);
 
@@ -34,7 +21,7 @@ function Widget() {
           </button>
         </div>
         <div className="widget-select">
-          <Select options={financialOptions} name="financialOptions" />
+          <Select name="financialOptions" />
         </div>
       </div>
       {isPopUpOpen && <InfoPopUp handleClose={togglePopUp} />}

--- a/widget/src/providers/CreditAgreementsProvider.tsx
+++ b/widget/src/providers/CreditAgreementsProvider.tsx
@@ -1,13 +1,30 @@
-import { createContext, useMemo, useState } from "react";
+import { createContext, useEffect, useMemo, useState } from "react";
 
 import useCreditAgreements, {
   CreditAgreement,
 } from "../hooks/useCreditAgreements";
+import { SelectOption } from "../components/Select/Select";
+
+function getProductPrice(productPriceElement: HTMLElement) {
+  const productPriceStringValue = productPriceElement.textContent?.replace(
+    ",",
+    "."
+  );
+
+  const productPrice =
+    productPriceStringValue && parseFloat(productPriceStringValue);
+
+  const productPriceInEurCents = productPrice && productPrice * 100;
+
+  return productPriceInEurCents;
+}
 
 export interface CreditAgreementsContextType {
   creditAgreements: CreditAgreement[];
   instalmentFee: string;
   setPrice: React.Dispatch<React.SetStateAction<number>>;
+  creditSelected: SelectOption | null;
+  setCreditSelected: React.Dispatch<React.SetStateAction<SelectOption | null>>;
 }
 
 export const CreditAgreementsContext =
@@ -19,6 +36,34 @@ type Props = {
 
 const CreditAgreementsProvider = ({ children }: Props) => {
   const [price, setPrice] = useState<number>(0);
+  const [creditSelected, setCreditSelected] = useState<SelectOption | null>(
+    null
+  );
+
+  const updatePrice = () => {
+    const productPriceElement = document.getElementById("product-price");
+
+    const price = productPriceElement && getProductPrice(productPriceElement);
+
+    if (price) {
+      setPrice(price);
+    }
+
+    // On price updated, reset the selected option value
+    setCreditSelected(null);
+  };
+
+  useEffect(() => {
+    Array.from(document.getElementsByClassName("product-capacity")).map(
+      (element) => element.addEventListener("click", updatePrice)
+    );
+
+    return () => {
+      Array.from(document.getElementsByClassName("product-capacity")).map(
+        (element) => element.removeEventListener("click", updatePrice)
+      );
+    };
+  });
 
   const { creditAgreements, instalmentFee } = useCreditAgreements(price);
 
@@ -27,8 +72,10 @@ const CreditAgreementsProvider = ({ children }: Props) => {
       creditAgreements,
       instalmentFee,
       setPrice,
+      creditSelected,
+      setCreditSelected,
     }),
-    [creditAgreements, instalmentFee]
+    [creditAgreements, creditSelected, instalmentFee]
   );
 
   return (

--- a/widget/src/providers/CreditAgreementsProvider.tsx
+++ b/widget/src/providers/CreditAgreementsProvider.tsx
@@ -22,7 +22,6 @@ function getProductPrice(productPriceElement: HTMLElement) {
 export interface CreditAgreementsContextType {
   creditAgreements: CreditAgreement[];
   instalmentFee: string;
-  setPrice: React.Dispatch<React.SetStateAction<number>>;
   creditSelected: SelectOption | null;
   setCreditSelected: React.Dispatch<React.SetStateAction<SelectOption | null>>;
 }
@@ -63,7 +62,7 @@ const CreditAgreementsProvider = ({ children }: Props) => {
         (element) => element.removeEventListener("click", updatePrice)
       );
     };
-  });
+  }, []);
 
   const { creditAgreements, instalmentFee } = useCreditAgreements(price);
 
@@ -71,7 +70,6 @@ const CreditAgreementsProvider = ({ children }: Props) => {
     () => ({
       creditAgreements,
       instalmentFee,
-      setPrice,
       creditSelected,
       setCreditSelected,
     }),


### PR DESCRIPTION
This PR addresses: 
- Move some logic to the context provider.
- Add event listener to the price changed to update the options displayed in the select and reset the selected.